### PR TITLE
Галерея не показывается у пустого шаблона

### DIFF
--- a/core/components/ms2gallery/elements/plugins/plugin.ms2gallery.php
+++ b/core/components/ms2gallery/elements/plugins/plugin.ms2gallery.php
@@ -6,7 +6,9 @@ switch ($modx->event->name) {
 		if ($resource instanceof msProduct || $mode == 'new') {
 			return;
 		}
-		elseif (in_array($resource->get('template'), array_map('trim', explode(',', $modx->getOption('ms2gallery_disable_for_templates'))))) {
+		$template = $resource->get('template')
+		$disabled = array_map('trim', explode(',', $modx->getOption('ms2gallery_disable_for_templates')));
+		elseif (($disabled[0] !== '') && in_array($template, $disabled)) {
 			return;
 		}
 		$modx23 = !empty($modx->version) && version_compare($modx->version['full_version'], '2.3.0', '>=');


### PR DESCRIPTION
Видимо in_array не проверяет типы и поэтому, если настройка пустая, то для пустого шаблона (id=0) галерея не показывается. Исправление.