### PR TITLE
Возврат созданного объекта при загрузке

### DIFF
--- a/core/components/ms2gallery/processors/mgr/gallery/upload.class.php
+++ b/core/components/ms2gallery/processors/mgr/gallery/upload.class.php
@@ -120,7 +120,7 @@ class msResourceFileUploadProcessor extends modObjectProcessor {
 				return $this->failure($this->modx->lexicon('ms2gallery_err_gallery_thumb'));
 			}
 			else {
-				return $this->success();
+				return $this->success('', $product_file);
 			}
 		}
 		else {


### PR DESCRIPTION
При ручном вызове процессора необходим доступ к только что созданному объекту.