### PR TITLE
Сортировка не-изображений в админке

### DIFF
--- a/core/components/ms2gallery/model/ms2gallery/ms2gallery.class.php
+++ b/core/components/ms2gallery/model/ms2gallery/ms2gallery.class.php
@@ -146,7 +146,7 @@ class ms2Gallery {
 			return;
 		}
 
-		$q = $this->modx->newQuery('msResourceFile', array('resource_id' => $resource_id, 'parent' => 0, 'type' => 'image'));
+		$q = $this->modx->newQuery('msResourceFile', array('resource_id' => $resource_id, 'parent' => 0));
 		$q->select('id');
 		$q->sortby('rank ASC, createdon', 'ASC');
 
@@ -155,7 +155,7 @@ class ms2Gallery {
 			$table = $this->modx->getTableName('msResourceFile');
 			if ($ids = $q->stmt->fetchAll(PDO::FETCH_COLUMN)) {
 				foreach ($ids as $k => $id) {
-					$sql .= "UPDATE {$table} SET `rank` = '{$k}' WHERE `type` = 'image' AND (`id` = {$id} OR `parent` = {$id});";
+					$sql .= "UPDATE {$table} SET `rank` = '{$k}' WHERE (`id` = {$id} OR `parent` = {$id});";
 				}
 			}
 			$sql .= "ALTER TABLE {$table} ORDER BY `rank` ASC;";

--- a/core/components/ms2gallery/processors/mgr/gallery/sort.class.php
+++ b/core/components/ms2gallery/processors/mgr/gallery/sort.class.php
@@ -25,7 +25,6 @@ class msResourceFileSortProcessor extends modObjectProcessor {
 				SET rank = rank - 1 WHERE
 					resource_id = " . $resource_id . "
 					AND parent = 0
-					AND type = 'image'
 					AND rank <= {$target->get('rank')}
 					AND rank > {$source->get('rank')}
 					AND rank > 0
@@ -37,7 +36,6 @@ class msResourceFileSortProcessor extends modObjectProcessor {
 				SET rank = rank + 1 WHERE
 					resource_id = " . $resource_id . "
 					AND parent = 0
-					AND type = 'image'
 					AND rank >= {$target->get('rank')}
 					AND rank < {$source->get('rank')}
 			");


### PR DESCRIPTION
Если загружать в галерею файлы, не являющиеся изображениями, то их сортировка в админке работает неправильно, rank выставляется неверно.